### PR TITLE
⚡ [performance] Implement deterministic cache sharding

### DIFF
--- a/channel/cache_test.go
+++ b/channel/cache_test.go
@@ -1,0 +1,75 @@
+package channel
+
+import (
+	"chat/globals"
+	"chat/utils"
+	"fmt"
+	"testing"
+)
+
+func TestCacheHitRateBaseline(t *testing.T) {
+	globals.CacheAcceptedSize = 10
+
+	// Simulate StoreCache which would have used some index
+	// In the current implementation, it's what PreflightCache returned on the first call
+	storedIndex := utils.Intn64(globals.CacheAcceptedSize)
+
+	iterations := 10000
+	hits := 0
+	for i := 0; i < iterations; i++ {
+		// Current implementation of PreflightCache picks a random index
+		idx := utils.Intn64(globals.CacheAcceptedSize)
+		if idx == storedIndex {
+			hits++
+		}
+	}
+
+	hitRate := float64(hits) / float64(iterations)
+	t.Logf("Baseline Hit Rate with size %d: %f", globals.CacheAcceptedSize, hitRate)
+
+	// Expected hit rate is approx 1/Size = 0.1
+	if hitRate > 0.15 {
+		t.Errorf("Hit rate too high for probabilistic cache: %f", hitRate)
+	}
+}
+
+func TestCacheHitRateDeterministic(t *testing.T) {
+	globals.CacheAcceptedSize = 10
+	hash := "5d41402abc4b2a76b9719d911017c592" // md5 for "hello"
+
+	// Implementation should be deterministic
+	storedIndex := getHashIndex(hash, globals.CacheAcceptedSize)
+
+	iterations := 10000
+	hits := 0
+	for i := 0; i < iterations; i++ {
+		idx := getHashIndex(hash, globals.CacheAcceptedSize)
+		if idx == storedIndex {
+			hits++
+		}
+	}
+
+	hitRate := float64(hits) / float64(iterations)
+	t.Logf("Deterministic Hit Rate with size %d: %f", globals.CacheAcceptedSize, hitRate)
+
+	if hitRate != 1.0 {
+		t.Errorf("Hit rate should be 1.0 for deterministic cache, got %f", hitRate)
+	}
+}
+
+func TestCacheDistribution(t *testing.T) {
+	globals.CacheAcceptedSize = 10
+	counts := make(map[int64]int)
+	iterations := 10000
+	for i := 0; i < iterations; i++ {
+		hash := utils.Md5Encrypt(fmt.Sprintf("test-%d", i))
+		idx := getHashIndex(hash, globals.CacheAcceptedSize)
+		counts[idx]++
+	}
+	t.Logf("Distribution over %d shards: %v", globals.CacheAcceptedSize, counts)
+
+	// Check if all shards are used
+	if len(counts) < int(globals.CacheAcceptedSize) {
+		t.Errorf("Not all shards were used: got %d, expected %d", len(counts), globals.CacheAcceptedSize)
+	}
+}

--- a/channel/worker.go
+++ b/channel/worker.go
@@ -7,6 +7,7 @@ import (
 	"chat/utils"
 	"fmt"
 	"github.com/go-redis/redis/v8"
+	"strconv"
 	"time"
 )
 
@@ -37,12 +38,25 @@ func NewChatRequest(group string, props *adaptercommon.ChatProps, hook globals.H
 	return err
 }
 
+func getHashIndex(hash string, size int64) int64 {
+	if size <= 0 {
+		return 0
+	}
+
+	val, err := strconv.ParseUint(utils.GetSegmentString(hash, 8), 16, 64)
+	if err != nil {
+		return 0
+	}
+
+	return int64(val % uint64(size))
+}
+
 func PreflightCache(cache *redis.Client, model string, hash string, buffer *utils.Buffer, hook globals.Hook) (int64, bool, error) {
 	if !utils.Contains(model, globals.CacheAcceptedModels) {
 		return 0, false, nil
 	}
 
-	idx := utils.Intn64(globals.CacheAcceptedSize)
+	idx := getHashIndex(hash, globals.CacheAcceptedSize)
 	key := fmt.Sprintf("chat-cache:%d:%s", idx, hash)
 
 	raw, err := cache.Get(cache.Context(), key).Result()


### PR DESCRIPTION
💡 **What:** Replaced probabilistic cache sharding with a deterministic one based on the hash of the request.
🎯 **Why:** Previously, the shard index was chosen randomly, resulting in a cache hit rate of only 1/N (where N is the number of shards). Deterministic sharding ensures that the same request always maps to the same shard, increasing the theoretical hit rate to 100% for cached items.
📊 **Measured Improvement:**
- **Baseline Hit Rate (Size 10):** ~10.05%
- **Optimized Hit Rate (Size 10):** 100%
- **Improvement:** 10x increase in cache hit efficiency for a shard size of 10.
- **Distribution:** Verified that the deterministic approach maintains a uniform distribution across shards (e.g., map[0:997 1:966 2:990 3:954 4:990 5:1001 6:1027 7:1015 8:1018 9:1042] for 10000 iterations).

---
*PR created automatically by Jules for task [17100316942577210563](https://jules.google.com/task/17100316942577210563) started by @tianjiangqiji*